### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -16,7 +16,7 @@ class syntax_plugin_gitlab extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('\[\[gitlabapi>[a-zA-Z0-9.-]+>[a-z0-9]+\]\]', $mode, 'plugin_gitlab');
     }
 
-    public function handle($match, $state, $pos, Doku_Handler &$handler) {
+    public function handle($match, $state, $pos, Doku_Handler $handler) {
         list($name, $repository_name, $commit_id) = explode('>', $match);
         $commit_id_short = substr($commit_id, 0, -2);
         list($repository_id, $web_url)= $this->getInfoByName($repository_name);
@@ -25,7 +25,7 @@ class syntax_plugin_gitlab extends DokuWiki_Syntax_Plugin {
         return array($web_url, $commit_id_long, $commit_msg);
     }
 
-    public function render($mode, Doku_Renderer &$renderer, $data) {
+    public function render($mode, Doku_Renderer $renderer, $data) {
     // $data is what the function handle return'ed.
         if($mode == 'xhtml'){
             /** @var Doku_Renderer_xhtml $renderer */


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
